### PR TITLE
Added explicit exports

### DIFF
--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,2 +1,20 @@
 from .player import Player
 from .game_pieces import GamePieces, DevCard, Tile, Board
+from .interfaces import (
+    IDevCard, IEncounter, IGamePieces, 
+    IItem, IPlayer, ITile
+)
+
+__all__ = [
+    "Player",
+    "GamePieces",
+    "DevCard", 
+    "Tile",
+    "Board",
+    "IDevCard",
+    "IEncounter",
+    "IGamePieces",
+    "IItem", 
+    "IPlayer",
+    "ITile"
+]

--- a/src/model/game_pieces/__init__.py
+++ b/src/model/game_pieces/__init__.py
@@ -4,3 +4,14 @@ from ..interfaces.i_dev_card import IDevCard
 from ..interfaces.i_game_pieces import IGamePieces
 from ..interfaces.i_tile import ITile
 from .tile import Tile
+from .board import Board
+
+__all__ = [
+    "DevCard",
+    "GamePieces", 
+    "Tile",
+    "Board",
+    "IDevCard",
+    "IGamePieces",
+    "ITile"
+]

--- a/src/model/interfaces/__init__.py
+++ b/src/model/interfaces/__init__.py
@@ -4,3 +4,12 @@ from .i_game_pieces import IGamePieces
 from .i_item import IItem
 from .i_player import IPlayer
 from .i_tile import ITile
+
+__all__ = [
+    "IDevCard",
+    "IEncounter", 
+    "IGamePieces",
+    "IItem",
+    "IPlayer",
+    "ITile"
+]

--- a/src/model/player/__init__.py
+++ b/src/model/player/__init__.py
@@ -1,1 +1,3 @@
 from .player import Player
+
+__all__ = ["Player"]


### PR DESCRIPTION
Strict type settings show the imports as unused, after doing some research I found that using __all__ is the pythonic way of explicitly declaring that these are being re-exported as part of the public API.